### PR TITLE
fix: trigger docker build from release workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_call:
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,3 +72,10 @@ jobs:
           prerelease: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build-docker:
+    needs: release
+    if: needs.release.result == 'success'
+    uses: ./.github/workflows/docker-build.yml
+    secrets: inherit
+


### PR DESCRIPTION
Trigger Docker build automatically when release is created via workflow_call